### PR TITLE
fix(design-system): add accessible dialog title for screen readers

### DIFF
--- a/packages/design-system/components/search/search-dialog.tsx
+++ b/packages/design-system/components/search/search-dialog.tsx
@@ -148,7 +148,20 @@ export function SearchDialog({
       />
 
       {/* Dialog */}
-      <div className="fixed left-1/2 top-[20%] z-50 w-full max-w-2xl -translate-x-1/2 rounded-lg border border-border bg-background shadow-lg">
+      <div
+        role="dialog"
+        aria-labelledby="search-dialog-title"
+        aria-describedby="search-dialog-description"
+        className="fixed left-1/2 top-[20%] z-50 w-full max-w-2xl -translate-x-1/2 rounded-lg border border-border bg-background shadow-lg"
+      >
+        {/* Visually hidden title for screen readers */}
+        <h2 id="search-dialog-title" className="sr-only">
+          Search Design System
+        </h2>
+        <p id="search-dialog-description" className="sr-only">
+          Search for components, patterns, and documentation in the Fidus Design System
+        </p>
+
         {/* Search Input */}
         <div className="flex items-center gap-3 border-b border-border px-4 py-3">
           <Search className="h-5 w-5 text-muted-foreground" />


### PR DESCRIPTION
## Summary
Improves accessibility of the search dialog by adding proper ARIA attributes for screen readers.

## Changes
- Added `role="dialog"` attribute to search dialog container
- Added `aria-labelledby` and `aria-describedby` for screen reader announcements
- Added visually hidden `<h2>` title and `<p>` description using Tailwind's `sr-only` utility
- Fixes the DialogContent accessibility warning that appeared in browser console

## Testing
✅ Build successful - all 86 static pages generated
✅ All pre-push checks passed (Lint, Typecheck, Mermaid)
✅ Accessibility warning resolved

## Before
Console showed warning:
```
Warning: Failed prop type: Missing prop `DialogTitle` for `DialogContent`. Pass a `DialogTitle` or set `aria-describedby` on the content element.
```

## After
- Screen readers can properly announce the dialog title
- No accessibility warnings in console
- Dialog remains visually identical but semantically correct

## Related
- Fixes accessibility issue discovered in PR #20 after Vercel deployment
- Follows WCAG 2.1 guidelines for modal dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)