### PR TITLE
fix(design-system): fix mobile navigation z-index layering

### DIFF
--- a/packages/design-system/styles/globals.css
+++ b/packages/design-system/styles/globals.css
@@ -80,6 +80,8 @@
     --z-base: 0;
     --z-dropdown: 100;
     --z-sticky: 200;
+    --z-overlay: 250;
+    --z-sidebar: 260;
     --z-modal: 300;
     --z-popover: 400;
     --z-tooltip: 500;

--- a/packages/design-system/tailwind.config.ts
+++ b/packages/design-system/tailwind.config.ts
@@ -83,6 +83,8 @@ const config: Config = {
         base: 'var(--z-base)',
         dropdown: 'var(--z-dropdown)',
         sticky: 'var(--z-sticky)',
+        overlay: 'var(--z-overlay)',
+        sidebar: 'var(--z-sidebar)',
         modal: 'var(--z-modal)',
         popover: 'var(--z-popover)',
         tooltip: 'var(--z-tooltip)',


### PR DESCRIPTION
## Summary
Fixes mobile burger menu navigation where the backdrop overlay was covering the sidebar, making menu items unclickable.

## Problem
When opening the mobile menu (burger icon), the sidebar appeared but the backdrop overlay was rendered on top of it due to missing z-index definitions. This made all navigation links unclickable on mobile devices.

## Root Cause
The CSS classes `z-sidebar` and `z-overlay` were used in the code but were **not defined** in the design system:
- `sidebar.tsx` used `z-sidebar` (undefined → fallback to default)
- `layout-client.tsx` overlay used `z-overlay` (undefined → fallback to default)
- Both ended up with similar or conflicting z-index values

## Solution
Added proper z-index definitions to maintain correct layering:

### globals.css
```css
--z-overlay: 250   /* Backdrop overlay */
--z-sidebar: 260   /* Sidebar (above overlay) */
```

### tailwind.config.ts
```typescript
zIndex: {
  overlay: 'var(--z-overlay)',
  sidebar: 'var(--z-sidebar)',
}
```

## Z-Index Hierarchy
```
--z-base: 0
--z-dropdown: 100
--z-sticky: 200
--z-overlay: 250      ← NEW (backdrop)
--z-sidebar: 260      ← NEW (above backdrop)
--z-modal: 300
--z-popover: 400
--z-tooltip: 500
```

## Testing
✅ Build successful - all 86 static pages generated  
✅ All pre-push checks passed (Lint, Typecheck, Mermaid)  
✅ Verified z-index values are correctly applied  

## Impact
- **Mobile users** can now properly use the navigation menu
- **No breaking changes** - only adds missing CSS variables
- **Consistent with design system** z-index scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)