### PR TITLE
fix(design-system): auto-close mobile menu after navigation

### DIFF
--- a/packages/design-system/components/layout-client.tsx
+++ b/packages/design-system/components/layout-client.tsx
@@ -15,7 +15,7 @@ export function LayoutClient({ children }: { children: React.ReactNode }) {
         onMenuClick={() => setIsSidebarOpen(!isSidebarOpen)}
         onSearchClick={() => setIsSearchOpen(true)}
       />
-      <Sidebar isOpen={isSidebarOpen} />
+      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
       <SearchDialog
         isOpen={isSearchOpen}
         onClose={() => setIsSearchOpen(false)}

--- a/packages/design-system/components/navigation/sidebar.tsx
+++ b/packages/design-system/components/navigation/sidebar.tsx
@@ -177,7 +177,7 @@ const navigation: NavItem[] = [
   },
 ];
 
-function NavSection({ item }: { item: NavItem }) {
+function NavSection({ item, onLinkClick }: { item: NavItem; onLinkClick?: () => void }) {
   const pathname = usePathname();
 
   // Check if any child item is active (recursively)
@@ -214,7 +214,7 @@ function NavSection({ item }: { item: NavItem }) {
         {isOpen && (
           <div className="mt-1 space-y-1 pl-3">
             {item.items.map((subItem) => (
-              <NavItem key={subItem.href || subItem.title} item={subItem} />
+              <NavItem key={subItem.href || subItem.title} item={subItem} onLinkClick={onLinkClick} />
             ))}
           </div>
         )}
@@ -222,16 +222,16 @@ function NavSection({ item }: { item: NavItem }) {
     );
   }
 
-  return <NavItem item={item} />;
+  return <NavItem item={item} onLinkClick={onLinkClick} />;
 }
 
-function NavItem({ item }: { item: NavItem }) {
+function NavItem({ item, onLinkClick }: { item: NavItem; onLinkClick?: () => void }) {
   const pathname = usePathname();
   const isActive = pathname === item.href;
 
   // If item has sub-items, render as a nested section
   if (item.items) {
-    return <NavSection item={item} />;
+    return <NavSection item={item} onLinkClick={onLinkClick} />;
   }
 
   // If no href and no items, skip
@@ -240,6 +240,7 @@ function NavItem({ item }: { item: NavItem }) {
   return (
     <Link
       href={item.href}
+      onClick={onLinkClick}
       className={`block px-3 py-2 text-sm rounded-md transition-colors no-underline ${
         isActive
           ? 'bg-primary text-black font-bold'
@@ -251,7 +252,7 @@ function NavItem({ item }: { item: NavItem }) {
   );
 }
 
-export function Sidebar({ isOpen }: { isOpen?: boolean }) {
+export function Sidebar({ isOpen, onClose }: { isOpen?: boolean; onClose?: () => void }) {
   return (
     <aside
       className={`fixed top-16 left-0 z-sidebar h-[calc(100vh-4rem)] w-64 border-r border-border bg-background overflow-y-auto transition-transform lg:translate-x-0 ${
@@ -260,7 +261,7 @@ export function Sidebar({ isOpen }: { isOpen?: boolean }) {
     >
       <nav className="p-4">
         {navigation.map((item) => (
-          <NavSection key={item.title} item={item} />
+          <NavSection key={item.title} item={item} onLinkClick={onClose} />
         ))}
       </nav>
     </aside>


### PR DESCRIPTION
## Summary
Fixes mobile navigation UX by automatically closing the burger menu when a user selects a page.

## Problem
When using the mobile navigation (burger menu):
1. User opens burger menu
2. User clicks on a navigation link
3. Page loads but menu **stays open**
4. User has to manually close the menu or click the overlay

This creates a poor UX where the menu obscures content after navigation.

## Solution
Added auto-close functionality to the sidebar:
- Added `onClose` callback prop to `Sidebar` component
- Passed `onLinkClick` handler through `NavSection` and `NavItem` components
- Sidebar automatically closes when user clicks any navigation link
- Only affects mobile (desktop sidebar is always visible)

## Implementation

### Sidebar Component
```tsx
export function Sidebar({ isOpen, onClose }: { isOpen?: boolean; onClose?: () => void }) {
  return (
    <aside>
      <nav>
        {navigation.map((item) => (
          <NavSection item={item} onLinkClick={onClose} />  {/* Pass callback */}
        ))}
      </nav>
    </aside>
  );
}
```

### NavItem Component
```tsx
function NavItem({ item, onLinkClick }) {
  return (
    <Link href={item.href} onClick={onLinkClick}>  {/* Call on click */}
      {item.title}
    </Link>
  );
}
```

### Layout Client
```tsx
<Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
```

## User Flow

**Before:**
1. 📱 Open burger menu
2. 🖱️ Click "Components > Button"
3. 📄 Button page loads
4. ❌ Menu still open, blocking content
5. 🖱️ **Must manually close menu**

**After:**
1. 📱 Open burger menu
2. 🖱️ Click "Components > Button"
3. 📄 Button page loads
4. ✅ **Menu auto-closes automatically**
5. 🎉 Content immediately visible

## Testing
✅ Build successful - all 86 static pages generated  
✅ All pre-push checks passed (Lint, Typecheck, Mermaid)  
✅ Auto-close works for all navigation levels (top-level and nested items)  

## Accessibility
- No impact on keyboard navigation
- Focus management unchanged
- Screen reader experience unchanged

## Desktop Behavior
- **No change** - desktop sidebar is always visible
- Auto-close only applies to mobile (when sidebar slides in/out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)