### PR TITLE
feat(design-system): add Vercel Speed Insights integration

### DIFF
--- a/packages/design-system/app/layout.tsx
+++ b/packages/design-system/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import '../styles/globals.css';
 import { LayoutClient } from '../components/layout-client';
 
@@ -25,6 +26,7 @@ export default function RootLayout({
       <body className="min-h-screen bg-background font-sans antialiased">
         <LayoutClient>{children}</LayoutClient>
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -16,6 +16,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
     "eslint-config-next": "^14.2.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(next@14.2.33)(react@18.3.1)
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.2.0(next@14.2.33)(react@18.3.1)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
@@ -2683,6 +2686,34 @@ packages:
     peerDependenciesMeta:
       '@remix-run/react':
         optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+    dependencies:
+      next: 14.2.33(react-dom@18.3.1)(react@18.3.1)
+      react: 18.3.1
+    dev: false
+
+  /@vercel/speed-insights@1.2.0(next@14.2.33)(react@18.3.1):
+    resolution: {integrity: sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==}
+    requiresBuild: true
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
       next:


### PR DESCRIPTION
## Summary
Add Vercel Speed Insights to track Core Web Vitals and performance metrics for the Design System documentation site.

## Changes
- Installed `@vercel/speed-insights@1.2.0` package
- Added `<SpeedInsights />` component to root layout ([layout.tsx](packages/design-system/app/layout.tsx))
- Complements existing Analytics for complete observability

## What are Speed Insights?

Vercel Speed Insights automatically tracks:
- **Largest Contentful Paint (LCP)** - Loading performance
- **First Input Delay (FID)** - Interactivity
- **Cumulative Layout Shift (CLS)** - Visual stability
- **Time to First Byte (TTFB)** - Server response time
- **First Contentful Paint (FCP)** - Initial render

## Benefits
- Privacy-friendly (no cookies required)
- Automatic Core Web Vitals tracking
- Real user monitoring (RUM)
- Helps optimize site performance
- Works seamlessly with Vercel deployments

## Testing
```bash
# Build successful
cd packages/design-system
pnpm build

# All pre-push checks passed
✅ Lint
✅ Typecheck
✅ Mermaid diagrams
```

## Related
- Works alongside `@vercel/analytics` (added in #24)
- Both packages only activate in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)