### PR TITLE
fix(ui): v1.4.1 - Critical hotfix for Tailwind CSS hsl() wrapper

### DIFF
--- a/packages/design-system/tailwind.config.ts
+++ b/packages/design-system/tailwind.config.ts
@@ -1,108 +1,19 @@
 import type { Config } from 'tailwindcss';
+import fidusTailwindPreset from '../ui/tailwind.config';
 
+/**
+ * Design System Tailwind Configuration
+ *
+ * Uses the @fidus/ui Tailwind preset to ensure design consistency
+ * and proper color handling (HSL with opacity support).
+ */
 const config: Config = {
+  presets: [fidusTailwindPreset],
   content: [
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     '../ui/src/**/*.{js,ts,jsx,tsx}', // Include @fidus/ui components
   ],
-  theme: {
-    extend: {
-      colors: {
-        primary: {
-          DEFAULT: 'hsl(var(--color-primary))',
-          foreground: 'hsl(var(--color-primary-foreground))',
-          hover: 'hsl(var(--color-primary-hover))',
-          active: 'hsl(var(--color-primary-active))',
-        },
-        black: 'hsl(var(--color-black))',
-        white: 'hsl(var(--color-white))',
-        trust: {
-          local: 'hsl(var(--color-trust-local))',
-          cloud: 'hsl(var(--color-trust-cloud))',
-          encrypted: 'hsl(var(--color-trust-encrypted))',
-        },
-        success: 'hsl(var(--color-success))',
-        warning: 'hsl(var(--color-warning))',
-        error: 'hsl(var(--color-error))',
-        info: 'hsl(var(--color-info))',
-        urgent: 'hsl(var(--color-urgent))',
-        medium: 'hsl(var(--color-medium))',
-        low: 'hsl(var(--color-low))',
-        background: 'hsl(var(--color-background))',
-        foreground: 'hsl(var(--color-foreground))',
-        muted: {
-          DEFAULT: 'hsl(var(--color-muted))',
-          foreground: 'hsl(var(--color-muted-foreground))',
-        },
-        border: 'hsl(var(--color-border))',
-        input: 'hsl(var(--color-input-bg))',
-      },
-      fontFamily: {
-        sans: ['var(--font-sans)'],
-        mono: ['var(--font-mono)'],
-      },
-      fontSize: {
-        xs: 'var(--font-size-xs)',
-        sm: 'var(--font-size-sm)',
-        md: 'var(--font-size-md)',
-        lg: 'var(--font-size-lg)',
-        xl: 'var(--font-size-xl)',
-        '2xl': 'var(--font-size-2xl)',
-        '3xl': 'var(--font-size-3xl)',
-        '4xl': 'var(--font-size-4xl)',
-      },
-      lineHeight: {
-        tight: 'var(--line-height-tight)',
-        normal: 'var(--line-height-normal)',
-        relaxed: 'var(--line-height-relaxed)',
-      },
-      spacing: {
-        xs: 'var(--spacing-xs)',
-        sm: 'var(--spacing-sm)',
-        md: 'var(--spacing-md)',
-        lg: 'var(--spacing-lg)',
-        xl: 'var(--spacing-xl)',
-        '2xl': 'var(--spacing-2xl)',
-        '3xl': 'var(--spacing-3xl)',
-      },
-      borderRadius: {
-        sm: 'var(--radius-sm)',
-        md: 'var(--radius-md)',
-        lg: 'var(--radius-lg)',
-        xl: 'var(--radius-xl)',
-        full: 'var(--radius-full)',
-      },
-      boxShadow: {
-        sm: 'var(--shadow-sm)',
-        md: 'var(--shadow-md)',
-        lg: 'var(--shadow-lg)',
-        xl: 'var(--shadow-xl)',
-      },
-      zIndex: {
-        base: 'var(--z-base)',
-        dropdown: 'var(--z-dropdown)',
-        sticky: 'var(--z-sticky)',
-        overlay: 'var(--z-overlay)',
-        sidebar: 'var(--z-sidebar)',
-        modal: 'var(--z-modal)',
-        popover: 'var(--z-popover)',
-        tooltip: 'var(--z-tooltip)',
-      },
-      transitionDuration: {
-        fast: 'var(--duration-fast)',
-        normal: 'var(--duration-normal)',
-        slow: 'var(--duration-slow)',
-      },
-      transitionTimingFunction: {
-        standard: 'var(--easing-standard)',
-        decelerate: 'var(--easing-decelerate)',
-        accelerate: 'var(--easing-accelerate)',
-      },
-    },
-  },
-  plugins: [],
-  darkMode: 'class',
 };
 
 export default config;

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.4.1
+
+### Patch Changes
+
+- fix(tailwind): preserve hsl() wrapper for Tailwind CSS v3+ compatibility
+
+  **Critical Bug Fix for v1.4.0**
+
+  Fixed a critical issue where Tailwind CSS v3+ would strip the `hsl()` wrapper from color definitions, causing invalid CSS output like `background-color: 45 100% 51%` instead of `background-color: hsl(45 100% 51%)`.
+
+  **Changes:**
+  - Updated color helper function to use `<alpha-value>` placeholder pattern: `hsl(var(--color-primary) / <alpha-value>)`
+  - This pattern forces Tailwind to preserve the `hsl()` wrapper while enabling opacity modifiers (e.g., `bg-primary/50`)
+  - All color definitions now use the new `hslColor()` helper function
+
+  **Technical Details:**
+  - Previous approach: `'hsl(var(--color-primary))'` - Tailwind v3+ stripped the wrapper
+  - New approach: `'hsl(var(--color-primary) / <alpha-value>)'` - Tailwind preserves the wrapper
+
+  **Impact:**
+  - Components now render with correct colors
+  - Opacity modifiers work correctly (e.g., `bg-primary/50`, `text-error/80`)
+  - No breaking changes to component APIs or CSS variable names
+
+  **Migration:**
+  Users on v1.4.0 should upgrade immediately. No code changes required - just update the package version.
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -581,10 +581,47 @@ Override CSS variables in your global CSS file, not in `tailwind.config.ts`:
 
 ### Module not found: '@fidus/ui/tailwind'
 
-**Cause**: Old version of `@fidus/ui` (< 1.3.2)
+**Cause**: Old version of `@fidus/ui` (< 1.4.0)
 
 **Solution**:
 Update to latest version: `npm install @fidus/ui@latest`
+
+### Colors not working in v1.4.0 (CRITICAL BUG - FIXED in v1.4.1)
+
+**Cause**: Tailwind CSS v3+ strips `hsl()` wrapper from color definitions, even when defined as strings. This causes CSS like `background-color: 45 100% 51%` (invalid) instead of `background-color: hsl(45 100% 51%)`.
+
+**Solution**:
+Update to `@fidus/ui@1.4.1` or later, which uses the `<alpha-value>` placeholder pattern:
+
+```bash
+npm install @fidus/ui@latest
+```
+
+**If you cannot upgrade immediately**, add this workaround to your global CSS:
+
+```css
+/* Temporary workaround for @fidus/ui@1.4.0 color bug */
+@layer utilities {
+  .bg-primary { background-color: hsl(var(--color-primary)) !important; }
+  .text-primary { color: hsl(var(--color-primary)) !important; }
+  .border-primary { border-color: hsl(var(--color-primary)) !important; }
+
+  .bg-success { background-color: hsl(var(--color-success)) !important; }
+  .text-success { color: hsl(var(--color-success)) !important; }
+
+  .bg-error { background-color: hsl(var(--color-error)) !important; }
+  .text-error { color: hsl(var(--color-error)) !important; }
+
+  .bg-warning { background-color: hsl(var(--color-warning)) !important; }
+  .text-warning { color: hsl(var(--color-warning)) !important; }
+
+  /* Add other colors as needed... */
+}
+```
+
+**Technical Details**:
+- v1.4.0 used `'hsl(var(--color-primary))'` (string) which Tailwind CSS v3+ automatically optimizes away
+- v1.4.1 uses `'hsl(var(--color-primary) / <alpha-value>)'` which Tailwind preserves for opacity support
 
 ## Browser Support
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fidus/ui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Fidus UI Component Library",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -24,38 +24,45 @@ import type { Config } from 'tailwindcss';
  * export default config;
  * ```
  */
+/**
+ * Color helper function for HSL with opacity support
+ * Tailwind CSS v3+ requires this format to preserve hsl() wrapper
+ * and support opacity modifiers (e.g., bg-primary/50)
+ */
+const hslColor = (variable: string) => `hsl(var(${variable}) / <alpha-value>)`;
+
 const fidusTailwindPreset: Partial<Config> = {
   theme: {
     extend: {
       colors: {
         primary: {
-          DEFAULT: 'hsl(var(--color-primary))',
-          foreground: 'hsl(var(--color-primary-foreground))',
-          hover: 'hsl(var(--color-primary-hover))',
-          active: 'hsl(var(--color-primary-active))',
+          DEFAULT: hslColor('--color-primary'),
+          foreground: hslColor('--color-primary-foreground'),
+          hover: hslColor('--color-primary-hover'),
+          active: hslColor('--color-primary-active'),
         },
-        black: 'hsl(var(--color-black))',
-        white: 'hsl(var(--color-white))',
+        black: hslColor('--color-black'),
+        white: hslColor('--color-white'),
         trust: {
-          local: 'hsl(var(--color-trust-local))',
-          cloud: 'hsl(var(--color-trust-cloud))',
-          encrypted: 'hsl(var(--color-trust-encrypted))',
+          local: hslColor('--color-trust-local'),
+          cloud: hslColor('--color-trust-cloud'),
+          encrypted: hslColor('--color-trust-encrypted'),
         },
-        success: 'hsl(var(--color-success))',
-        warning: 'hsl(var(--color-warning))',
-        error: 'hsl(var(--color-error))',
-        info: 'hsl(var(--color-info))',
-        urgent: 'hsl(var(--color-urgent))',
-        medium: 'hsl(var(--color-medium))',
-        low: 'hsl(var(--color-low))',
-        background: 'hsl(var(--color-background))',
-        foreground: 'hsl(var(--color-foreground))',
+        success: hslColor('--color-success'),
+        warning: hslColor('--color-warning'),
+        error: hslColor('--color-error'),
+        info: hslColor('--color-info'),
+        urgent: hslColor('--color-urgent'),
+        medium: hslColor('--color-medium'),
+        low: hslColor('--color-low'),
+        background: hslColor('--color-background'),
+        foreground: hslColor('--color-foreground'),
         muted: {
-          DEFAULT: 'hsl(var(--color-muted))',
-          foreground: 'hsl(var(--color-muted-foreground))',
+          DEFAULT: hslColor('--color-muted'),
+          foreground: hslColor('--color-muted-foreground'),
         },
-        border: 'hsl(var(--color-border))',
-        input: 'hsl(var(--color-input-bg))',
+        border: hslColor('--color-border'),
+        input: hslColor('--color-input-bg'),
       },
       fontFamily: {
         sans: ['var(--font-sans)'],


### PR DESCRIPTION
## Summary

Critical hotfix for v1.4.0 where Tailwind CSS v3+ stripped the `hsl()` wrapper from color definitions, causing invalid CSS output and breaking component colors.

## Changes

- ✅ Updated color helper function to use `<alpha-value>` placeholder pattern
- ✅ All color definitions now use `hslColor()` helper: `hsl(var(--color) / <alpha-value>)`
- ✅ Updated design-system to use @fidus/ui Tailwind preset
- ✅ Added comprehensive troubleshooting documentation

## Technical Details

**Problem:**
- v1.4.0 used: `'hsl(var(--color-primary))'` (string)
- Tailwind CSS v3+ optimizes away the `hsl()` wrapper
- Result: Invalid CSS like `background-color: 45 100% 51%`

**Solution:**
- v1.4.1 uses: `'hsl(var(--color-primary) / <alpha-value>)'`
- Tailwind preserves the `hsl()` wrapper for opacity support
- Result: Valid CSS like `background-color: hsl(45 100% 51% / 1)`

## Impact

- ✅ Components render with correct colors
- ✅ Opacity modifiers work correctly (e.g., `bg-primary/50`, `text-error/80`)
- ✅ No breaking changes to component APIs
- ✅ No breaking changes to CSS variable names

## Testing

- ✅ Build successful (`pnpm --filter @fidus/ui build`)
- ✅ Typecheck passed (`pnpm --filter @fidus/ui typecheck`)
- ✅ Design system build successful with proper CSS output
- ✅ Generated CSS verified to include `hsl()` wrappers

## Migration

Users on v1.4.0 should upgrade immediately:

```bash
npm install @fidus/ui@latest
```

No code changes required - just update the package version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)