### PR TITLE
chore: release v1.7.2

### DIFF
--- a/.changeset/tiny-release-design-system-fix.md
+++ b/.changeset/tiny-release-design-system-fix.md
@@ -1,9 +1,0 @@
----
-"@fidus/ui": patch
----
-
-Fix design system build errors with missing type imports
-
-- Add missing `Message` type imports in design system pages
-- Fix double semicolons in import statements
-- Ensure all 97 pages build successfully

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fidus/design-system",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.7.2
+
+### Patch Changes
+
+- 38b6713: Fix design system build errors with missing type imports
+  - Add missing `Message` type imports in design system pages
+  - Fix double semicolons in import statements
+  - Ensure all 97 pages build successfully
+
 ## 1.7.1
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fidus/ui",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Fidus UI Component Library",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Release v1.7.2

Patch release for @fidus/ui with bug fixes from design system migration.

### Changes

**@fidus/ui@1.7.2**
- Fix missing Message type imports in design system pages
- Fix double semicolons in import statements
- Ensure all 97 design system pages build successfully

**@fidus/design-system@1.7.2**
- Version synced with @fidus/ui via automated script

### Testing

- ✅ All builds pass
- ✅ All type checks pass
- ✅ All linting passes
- ✅ Design system builds with all 97 pages

### Release Process

After merge:
1. Checkout main and pull
2. Run `pnpm release` to publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)